### PR TITLE
Bypass prompt if renaming asset in the same directory

### DIFF
--- a/Packages/com.varneon.asset-move-prompt/Editor/AssetMovePrompt.cs
+++ b/Packages/com.varneon.asset-move-prompt/Editor/AssetMovePrompt.cs
@@ -24,7 +24,7 @@ namespace Varneon.AssetMovePrompt
             // If the file is being renamed in the same folder, bypass the prompt
             if (Path.GetDirectoryName(sourcePath).Equals(Path.GetDirectoryName(destinationPath))) { return AssetMoveResult.DidNotMove; }
 
-            // If this method gets invoked withing the time window, return the cached result
+            // If this method gets invoked within the time window, return the cached result
             if(DateTime.Now < modificationTimeWindow) { return moveResult; }
 
             // Check if the user intended to move the assets

--- a/Packages/com.varneon.asset-move-prompt/Editor/AssetMovePrompt.cs
+++ b/Packages/com.varneon.asset-move-prompt/Editor/AssetMovePrompt.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using UnityEditor;
 
 namespace Varneon.AssetMovePrompt
@@ -20,6 +21,9 @@ namespace Varneon.AssetMovePrompt
 
         private static AssetMoveResult OnWillMoveAsset(string sourcePath, string destinationPath)
         {
+            // If the file is being renamed in the same folder, bypass the prompt
+            if (Path.GetDirectoryName(sourcePath).Equals(Path.GetDirectoryName(destinationPath))) { return AssetMoveResult.DidNotMove; }
+
             // If this method gets invoked withing the time window, return the cached result
             if(DateTime.Now < modificationTimeWindow) { return moveResult; }
 

--- a/Packages/com.varneon.asset-move-prompt/package.json
+++ b/Packages/com.varneon.asset-move-prompt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.varneon.asset-move-prompt",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Simple dialog for verifying user's intentions of moving assets inside Unity",
   "displayName": "Asset Move Prompt",
   "author": {


### PR DESCRIPTION
Prompt will not be displayed anymore if an asset is being renamed in the same directory

Closes #1 